### PR TITLE
map ufuncs and dunder ops

### DIFF
--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -49,6 +49,12 @@ def test_ufunc():
     assert (s.ak + s.ak).tolist() == [[2, 4, 6], [8, 10], [12]]
     assert (s.ak + s).tolist() == [[2, 4, 6], [8, 10], [12]]
 
+    s = pd.DataFrame({"a": pd.Series(a)})
+    assert (s.ak + 1).a.tolist() == [[2, 3, 4], [5, 6], [7]]
+
+    assert (s.ak + s.ak).a.tolist() == [[2, 4, 6], [8, 10], [12]]
+    assert (s.ak + s).a.tolist() == [[2, 4, 6], [8, 10], [12]]
+
 
 def test_to_autoarrow():
     a = [[1, 2, 3], [4, 5], [6]]


### PR DESCRIPTION
Uses the same transform pattern for `df.ak + a` or `func(df.ak)`, to make them more similar to apply and ak.func (str, etc) patterns.